### PR TITLE
feat: dynamically calculate max loop count for file upload

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "cli_version": "1.2.2",
+  "cli_version": "1.2.3",
   "gui_version": "1.2.2"
 }


### PR DESCRIPTION
This pull request includes updates to improve the robustness of the `workerSlice` function, a minor adjustment to the import order in `main.go`, and a version bump in `version.json`. The most important changes are grouped below by theme.

### Code robustness improvements:

* [`cmd/tmplink-cli/main.go`](diffhunk://#diff-6d7e1e7b51a545b8a15714f2c148879456a00caad6788346540b86144ced7266L712-R720): Enhanced the `workerSlice` function to dynamically calculate the maximum loop count based on file size and chunk size, ensuring better handling of large files and reducing the risk of infinite loops. Added debug logging for estimated chunk count and maximum loop count.

### Code organization:

* [`cmd/tmplink-cli/main.go`](diffhunk://#diff-6d7e1e7b51a545b8a15714f2c148879456a00caad6788346540b86144ced7266R20-L22): Adjusted the import order to group external and internal dependencies more logically.

### Version update:

* [`version.json`](diffhunk://#diff-093664cc0c7cf4a76165141e93265eeb139f655bbee8105ed3ee2534a612354cL2-R2): Updated the CLI version from `1.2.2` to `1.2.3` to reflect the new changes in functionality.…hunk size and expected chunks